### PR TITLE
Fix type of subscriptionId

### DIFF
--- a/src/Response/Models/TransactionModel.php
+++ b/src/Response/Models/TransactionModel.php
@@ -62,7 +62,7 @@ class TransactionModel extends BaseModel
     public ?int    $type                                  = null;
     public ?bool   $refunded                              = null;
     public ?string $name                                  = null;
-    public ?int    $subscriptionId                        = null;
+    public ?string $subscriptionId                        = null;
     public ?bool   $isLocalOrder                          = null;
     public ?bool   $hideInvoiceId                         = null;
     public ?string $token                                 = null;


### PR DESCRIPTION
Согласно документации https://developers.cloudpayments.ru/#pay SubscriptionId имеет тип String, но в TransactionModel указан тип Int, что при получении данных транзакции (метод getPaymentData), для которой в процессе оплаты была создана подписка, вызывает следующую ошибку: 

> Cannot assign string to property Flowwow\Cloudpayments\Response\Models\TransactionModel::$subscriptionId of type ?int {"exception":"[object] (TypeError(code: 0): Cannot assign string to property Flowwow\\Cloudpayments\\Response\\Models\\TransactionModel::$subscriptionId of type ?int

Данный fork меняет тип свойства SubscriptionId для src/Response/Models/TransactionModel.php