### PR TITLE
FB-2681 add new fee fields to hook and response

### DIFF
--- a/src/Hook/HookPay.php
+++ b/src/Hook/HookPay.php
@@ -46,4 +46,7 @@ class HookPay extends BaseHook
     public ?string $cardProduct                           = null;
     public ?string $paymentMethod                         = null;
     public ?int    $fallBackScenarioDeclinedTransactionId = null;
+    public ?float  $vatAboveTotalFee                      = null;
+    public ?float  $processorAndPartnerFee                = null;
+    public ?float  $vatWithinProcessorFee                 = null;
 }

--- a/src/Response/Models/TransactionModel.php
+++ b/src/Response/Models/TransactionModel.php
@@ -80,6 +80,7 @@ class TransactionModel extends BaseModel
     /** @var SbpBankModelV2[]|null  */
     public ?array  $sbpBankModelsV2                       = null;
     public ?array  $splits                                = null;
+    public ?float  $vatAboveTotalFee                      = null;
 
     /**
      * Получение переведенного кода ошибки


### PR DESCRIPTION
Добавляем новый параметр:
**vatAboveTotalFee** — расчётная сумма НДС, начисляемая дополнительно к общей комиссии

Параметр будет передаваться в ответах
и уведомлениях для следующих операций:
- оплата по криптограмме (payments/cards/charge
и payments/cards/auth)
- оплата по токену (payments/tokens/charge
и payments/tokens/auth)
- выплата по криптограмме (payments/cards/topup)
- выплата по токену (payments/token/topup)
- выплата по СБП (payments/alt/topup)
- просмотр транзакции (payments/get)
- выгрузка списка транзакций (payments/list)

- выгрузка списка транзакций за произвольный
период (v2/payments/list)

**Pay-уведомления**
Этот параметр предоставит дополнительную информацию о НДС, начисленном над общей комиссией

**Изменения для СБП**

Для транзакций, прошедших по СБП, в Pay-уведомления добавляются параметры:
**ProcessorAndPartnerFee** — общая сумма комиссий (CloudPayments и партнёра)
**VatWithinProcessorFee** — сумма НДС, начисленного на комиссию CloudPayments (НДС уже включён в комиссию)

Параметры передаются только для Pay-уведомлений с типом СБП, который определяется по параметру PaymentMethod со значением Sbp.

Актуальная версия доступна [по ссылке →](http://link.cp.ru/cloudpaymentss/4834,=0K1xwqj8cPbojoMGd0IYIMw/5845,5225,93435,,ULXev4JnVSYuJlXdgMBE1lQ?aHR0cHM6Ly9kZXZlbG9wZXJzLmNsb3VkcGF5bWVudHMucnUvJTIzJTIzJTIzJTIzJTIzcGF5)